### PR TITLE
feat: Add VerifyDafnyJobs parameter

### DIFF
--- a/Source/dafny.msbuild/DafnyVerifyTask.cs
+++ b/Source/dafny.msbuild/DafnyVerifyTask.cs
@@ -22,9 +22,16 @@ namespace DafnyMSBuild
         [Required]
         public string TimeLimit { get; set; }
         
+        public string Jobs { get; set; }
+
         public override bool Execute()
         {
-            return DafnySourceFiles.AsParallel().All(VerifyDafnyFile);
+            ParallelQuery<ITaskItem> query = DafnySourceFiles.AsParallel();
+            if (Jobs != null)
+            {
+                query = query.WithDegreeOfParallelism(int.Parse(Jobs));
+            }
+            return query.All(VerifyDafnyFile);
         }
 
         private bool VerifyDafnyFile(ITaskItem file)

--- a/Source/dafny.msbuild/build/dafny.msbuild.targets
+++ b/Source/dafny.msbuild/build/dafny.msbuild.targets
@@ -1,7 +1,10 @@
 <Project>
     <!-- TODO: hook this up as a CodeAnalysis plugin instead? -->
     <Target Name="VerifyDafny">
-        <DafnyVerifyTask DafnySourceFiles="@(DafnySource)" DafnyExecutable="$(DafnyBinariesDir)$(Dafny)" TimeLimit="$(DafnyVerificationTimeLimit)" />
+        <DafnyVerifyTask DafnySourceFiles="@(DafnySource)" 
+                         DafnyExecutable="$(DafnyBinariesDir)$(Dafny)" 
+                         TimeLimit="$(DafnyVerificationTimeLimit)"
+                         Jobs="$(VerifyDafnyJobs)"/>
     </Target>
     
     <Target Name="CompileDafny"

--- a/Source/dafny.msbuild/dafny.msbuild.csproj
+++ b/Source/dafny.msbuild/dafny.msbuild.csproj
@@ -6,9 +6,10 @@
         <BuildOutputTargetFolder>tasks</BuildOutputTargetFolder>
         <!-- Stop dotnet from complaining about the non-standard layout -->
         <NoPackageAnalysis>true</NoPackageAnalysis>
+        <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         
-        <VersionPrefix>0.1.2</VersionPrefix>
-        <VersionSuffix>build$([System.DateTime]::Now.ToString('yyyyMMdd-HHmm'))</VersionSuffix>
+        <VersionPrefix>0.2.0</VersionPrefix>
+        <VersionSuffix Condition="$(Configuration) == 'Debug'">build$([System.DateTime]::Now.ToString('yyyyMMdd-HHmm'))</VersionSuffix>
         <RootNamespace>DafnyMSBuild</RootNamespace>
     </PropertyGroup>
 

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -16,7 +16,7 @@ phases:
       - msbuild boogie/Source/Boogie.sln
       # Get Dafny
       - git clone https://github.com/microsoft/dafny.git
-      - nuget restore dafny/Source/Boogie.sln
+      - nuget restore dafny/Source/Dafny.sln
       - msbuild dafny/Source/Dafny.sln
       - export PATH="$PWD/dafny/Binaries:$PATH"
       # Get Z3

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -28,4 +28,5 @@ phases:
       - dotnet build Source/dafny.msbuild.sln
       - cd Test
       - dotnet build -t:VerifyDafny
+      - dotnet build -t:VerifyDafny -p:VerifyDafnyJobs=1
       - dotnet test

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -16,6 +16,7 @@ phases:
       - msbuild boogie/Source/Boogie.sln
       # Get Dafny
       - git clone https://github.com/microsoft/dafny.git
+      - nuget restore dafny/Source/Boogie.sln
       - msbuild dafny/Source/Dafny.sln
       - export PATH="$PWD/dafny/Binaries:$PATH"
       # Get Z3


### PR DESCRIPTION
This controls the number of files that will be verified in parallel at once.

Also improved nuget packaging process (always pack, attach build info in DEBUG mode)