### PR TITLE
feat!: Make VerifyDafny take a list of params

### DIFF
--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Test VerifyDafny task (sequential)
         run: dotnet build dafny.msbuild/Test -t:VerifyDafny -p:VerifyDafnyJobs=1
       - name: Test VerifyDafny task (sequential with definite assignment)
-        run:
+        run: |
           if (dotnet build dafny.msbuild/Test -t:VerifyDafny -p:VerifyDafnyJobs=1 -p:VerifyTestProjectOverride="definiteAssignment:3") | grep -q 'Build FAILED.'; then
             echo "This failed, as it should have given the definiteAssignment flag"
             exit 0

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -57,8 +57,8 @@ jobs:
       - name: Test VerifyDafny task (parallel)
         run: dotnet build dafny.msbuild/Test -t:VerifyDafny
       - name: Test VerifyDafny task (sequential)
-        run: dotnet build dafny.msbuild/Test -t:VerifyDafny -p:DafnyVerifParams='"Jobs:1"'
+        run: dotnet build dafny.msbuild/Test -t:VerifyDafny -p:VerifyDafnyJobs=1
       - name: Test VerifyDafny task (sequential with definite assignment)
-        run: dotnet build dafny.msbuild/Test -t:VerifyDafny -p:DafnyVerifParams='"Jobs:1;definiteAssignment:3"'
+        run: dotnet build dafny.msbuild/Test -t:VerifyDafny -p:VerifyDafnyJobs=1 -p:VerifyDafnyPassthrough='"definiteAssignment:3"'
       - name: Run tests on TestProject
         run: dotnet test dafny.msbuild/Test

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -59,6 +59,13 @@ jobs:
       - name: Test VerifyDafny task (sequential)
         run: dotnet build dafny.msbuild/Test -t:VerifyDafny -p:VerifyDafnyJobs=1
       - name: Test VerifyDafny task (sequential with definite assignment)
-        run: dotnet build dafny.msbuild/Test -t:VerifyDafny -p:VerifyDafnyJobs=1 -p:VerifyTestProjectOverride="definiteAssignment:3"
+        run:
+          if (dotnet build dafny.msbuild/Test -t:VerifyDafny -p:VerifyDafnyJobs=1 -p:VerifyTestProjectOverride="definiteAssignment:3") | grep -q 'Build FAILED.'; then
+            echo "This failed, as it should have given the definiteAssignment flag"
+            exit 0
+          else
+            echo "This succeeded when it shouldn't have"
+            exit 1
+          fi
       - name: Run tests on TestProject
         run: dotnet test dafny.msbuild/Test

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -57,6 +57,8 @@ jobs:
       - name: Test VerifyDafny task (parallel)
         run: dotnet build dafny.msbuild/Test -t:VerifyDafny
       - name: Test VerifyDafny task (sequential)
-        run: dotnet build dafny.msbuild/Test -t:VerifyDafny -p:VerifyDafnyJobs=1
+        run: dotnet build dafny.msbuild/Test -t:VerifyDafny -p:DafnyVerifParams='"Jobs:1"'
+      - name: Test VerifyDafny task (sequential with definite assignment)
+        run: dotnet build dafny.msbuild/Test -t:VerifyDafny -p:DafnyVerifParams='"Jobs:1;definiteAssignment:3"'
       - name: Run tests on TestProject
         run: dotnet test dafny.msbuild/Test

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Test VerifyDafny task (sequential with definite assignment)
         run: |
           if (dotnet build dafny.msbuild/Test -t:VerifyDafny -p:VerifyDafnyJobs=1 -p:VerifyTestProjectOverride="definiteAssignment:3") | grep -q 'Build FAILED.'; then
-            echo "This failed, as it should have given the definiteAssignment flag"
+            echo "Failed as expected because the definiteAssignment flag was provided to Dafny with a value of 3"
             exit 0
           else
             echo "This succeeded when it shouldn't have"

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -59,6 +59,6 @@ jobs:
       - name: Test VerifyDafny task (sequential)
         run: dotnet build dafny.msbuild/Test -t:VerifyDafny -p:VerifyDafnyJobs=1
       - name: Test VerifyDafny task (sequential with definite assignment)
-        run: dotnet build dafny.msbuild/Test -t:VerifyDafny -p:VerifyDafnyJobs=1 -p:VerifyDafnyPassthrough='"definiteAssignment:3"'
+        run: dotnet build dafny.msbuild/Test -t:VerifyDafny -p:VerifyDafnyJobs=1 -p:VerifyTestProjectOverride="definiteAssignment:3"
       - name: Run tests on TestProject
         run: dotnet test dafny.msbuild/Test

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -60,7 +60,7 @@ jobs:
         run: dotnet build dafny.msbuild/Test -t:VerifyDafny -p:VerifyDafnyJobs=1
       - name: Test VerifyDafny task (sequential with definite assignment)
         run: |
-          if (dotnet build dafny.msbuild/Test -t:VerifyDafny -p:VerifyDafnyJobs=1 -p:VerifyTestProjectOverride="definiteAssignment:3") | grep -q 'Build FAILED.'; then
+          if (dotnet build dafny.msbuild/Test -t:VerifyDafny -p:VerifyDafnyJobs=1 -p:VerifyTestProjectOverride="definiteAssignment:1") | grep -q 'Build FAILED.'; then
             echo "This failed, as it should have given the definiteAssignment flag"
             exit 0
           else

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -60,7 +60,7 @@ jobs:
         run: dotnet build dafny.msbuild/Test -t:VerifyDafny -p:VerifyDafnyJobs=1
       - name: Test VerifyDafny task (sequential with definite assignment)
         run: |
-          if (dotnet build dafny.msbuild/Test -t:VerifyDafny -p:VerifyDafnyJobs=1 -p:VerifyTestProjectOverride="definiteAssignment:1") | grep -q 'Build FAILED.'; then
+          if (dotnet build dafny.msbuild/Test -t:VerifyDafny -p:VerifyDafnyJobs=1 -p:VerifyTestProjectOverride="definiteAssignment:3") | grep -q 'Build FAILED.'; then
             echo "This failed, as it should have given the definiteAssignment flag"
             exit 0
           else

--- a/Source/dafny.msbuild/DafnyVerifyTask.cs
+++ b/Source/dafny.msbuild/DafnyVerifyTask.cs
@@ -17,6 +17,7 @@ namespace DafnyMSBuild
     public class DafnyVerifyTask : Task
     {
         private static string JOB_KEY = "Jobs";
+        private static string[] REQUIRED_PARAMS = { "timeLimit" };
 
         [Required]
         public string DafnyExecutable { get; set; }
@@ -37,6 +38,11 @@ namespace DafnyMSBuild
                    throw new ArgumentException("Invalid verification argument, multiple :");
                 }
                 verificationParamsDict[keyVal[0]] = keyVal.Length == 2 ? keyVal[1] : "";
+            }
+            foreach (var requiredParam in REQUIRED_PARAMS) {
+                if (!verificationParamsDict.ContainsKey(requiredParam)) {
+                    throw new ArgumentException(String.Format("{0} required for verification", requiredParam));
+                }
             }
 
             // Determine if the verification task should be performed in parallel

--- a/Source/dafny.msbuild/build/dafny.msbuild.props
+++ b/Source/dafny.msbuild/build/dafny.msbuild.props
@@ -28,6 +28,10 @@
     </ItemGroup>
 
     <ItemGroup>
+        <DafnyShareParams Include="compile:0" />
+    </ItemGroup>
+
+    <ItemGroup>
         <DafnyVerifParams Include="timeLimit:30" />
     </ItemGroup>
 

--- a/Source/dafny.msbuild/build/dafny.msbuild.props
+++ b/Source/dafny.msbuild/build/dafny.msbuild.props
@@ -28,11 +28,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <DafnyShareParams Include="compile:0" />
-    </ItemGroup>
-
-    <ItemGroup>
-        <DafnyVerifParams Include="timeLimit:30" />
+        <VerifyDafnyPassthrough Include="timeLimit:30" />
     </ItemGroup>
 
     <UsingTask TaskName="DafnyMSBuild.DafnyVerifyTask" AssemblyFile="$(TaskAssembly)"/>

--- a/Source/dafny.msbuild/build/dafny.msbuild.props
+++ b/Source/dafny.msbuild/build/dafny.msbuild.props
@@ -21,12 +21,15 @@
         Binaries directory is already on your $PATH
         -->
         <DafnyBinariesDir></DafnyBinariesDir>
-        <DafnyVerificationTimeLimit>30</DafnyVerificationTimeLimit>
     </PropertyGroup>
 
     <ItemGroup>
         <DafnySource Include="**/*.dfy" />
     </ItemGroup>
-    
+
+    <ItemGroup>
+        <DafnyVerifParams Include="timeLimit:30" />
+    </ItemGroup>
+
     <UsingTask TaskName="DafnyMSBuild.DafnyVerifyTask" AssemblyFile="$(TaskAssembly)"/>
 </Project>

--- a/Source/dafny.msbuild/build/dafny.msbuild.targets
+++ b/Source/dafny.msbuild/build/dafny.msbuild.targets
@@ -3,8 +3,8 @@
     <Target Name="VerifyDafny">
         <DafnyVerifyTask DafnySourceFiles="@(DafnySource)" 
                          DafnyExecutable="$(DafnyBinariesDir)$(Dafny)"
-                         DafnyVerificationParams="$(DafnyVerifParams);@(DafnyVerifParams)"
-                         DafnySharedParams="$(DafnyShareParams);@(DafnyShareParams)"/>
+                         Jobs="$(VerifyDafnyJobs)"
+                         DafnyVerificationParams="@(VerifyDafnyPassthrough);$(VerifyDafnyPassthrough)" />
     </Target>
     
     <Target Name="CompileDafny"

--- a/Source/dafny.msbuild/build/dafny.msbuild.targets
+++ b/Source/dafny.msbuild/build/dafny.msbuild.targets
@@ -4,7 +4,7 @@
         <DafnyVerifyTask DafnySourceFiles="@(DafnySource)" 
                          DafnyExecutable="$(DafnyBinariesDir)$(Dafny)"
                          Jobs="$(VerifyDafnyJobs)"
-                         DafnyVerificationParams="@(VerifyDafnyPassthrough);$(VerifyDafnyPassthrough)" />
+                         DafnyVerificationParams="@(VerifyDafnyPassthrough)" />
     </Target>
     
     <Target Name="CompileDafny"

--- a/Source/dafny.msbuild/build/dafny.msbuild.targets
+++ b/Source/dafny.msbuild/build/dafny.msbuild.targets
@@ -3,7 +3,8 @@
     <Target Name="VerifyDafny">
         <DafnyVerifyTask DafnySourceFiles="@(DafnySource)" 
                          DafnyExecutable="$(DafnyBinariesDir)$(Dafny)"
-                         DafnyVerificationParams="$(DafnyVerifParams);@(DafnyVerifParams)"/>
+                         DafnyVerificationParams="$(DafnyVerifParams);@(DafnyVerifParams)"
+                         DafnySharedParams="$(DafnyShareParams);@(DafnyShareParams)"/>
     </Target>
     
     <Target Name="CompileDafny"

--- a/Source/dafny.msbuild/build/dafny.msbuild.targets
+++ b/Source/dafny.msbuild/build/dafny.msbuild.targets
@@ -3,8 +3,7 @@
     <Target Name="VerifyDafny">
         <DafnyVerifyTask DafnySourceFiles="@(DafnySource)" 
                          DafnyExecutable="$(DafnyBinariesDir)$(Dafny)"
-                         TimeLimit="$(DafnyVerificationTimeLimit)"
-                         Jobs="$(VerifyDafnyJobs)"/>
+                         DafnyVerificationParams="$(DafnyVerifParams);@(DafnyVerifParams)"/>
     </Target>
     
     <Target Name="CompileDafny"

--- a/Source/dafny.msbuild/dafny.msbuild.csproj
+++ b/Source/dafny.msbuild/dafny.msbuild.csproj
@@ -8,7 +8,7 @@
         <NoPackageAnalysis>true</NoPackageAnalysis>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         
-        <VersionPrefix>0.3.0</VersionPrefix>
+        <VersionPrefix>1.0.0</VersionPrefix>
         <VersionSuffix Condition="$(Configuration) == 'Debug'">build$([System.DateTime]::Now.ToString('yyyyMMdd-HHmm'))</VersionSuffix>
         <RootNamespace>DafnyMSBuild</RootNamespace>
     </PropertyGroup>
@@ -18,9 +18,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Build.Framework" Version="15.1.1012" PrivateAssets="All" />
-        <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.1.1012" PrivateAssets="All" />
+        <PackageReference Include="Microsoft.Build.Framework" Version="16.5.0" PrivateAssets="All" />
+        <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.5.0" PrivateAssets="All" />
         <PackageReference Include="System.Linq.Parallel" Version="4.3.0" PrivateAssets="All" />
     </ItemGroup>
-
 </Project>

--- a/Test/TestProject/TestProject.csproj
+++ b/Test/TestProject/TestProject.csproj
@@ -23,6 +23,6 @@
 
     <ItemGroup>
         <VerifyDafnyPassthrough Include="timeLimit:100" />
-        <VerifyDafnyPassthrough Include="$(VerifyDafnyPassthrough)" />
+        <VerifyDafnyPassthrough Include="$(VerifyTestProjectOverride)" />
     </ItemGroup>
 </Project>

--- a/Test/TestProject/TestProject.csproj
+++ b/Test/TestProject/TestProject.csproj
@@ -23,5 +23,6 @@
 
     <ItemGroup>
         <VerifyDafnyPassthrough Include="timeLimit:100" />
+        <VerifyDafnyPassthrough Include="$(VerifyDafnyPassthrough)" />
     </ItemGroup>
 </Project>

--- a/Test/TestProject/TestProject.csproj
+++ b/Test/TestProject/TestProject.csproj
@@ -22,6 +22,6 @@
     <Import Project="../../Source/dafny.msbuild/build/dafny.msbuild.targets" />
 
     <ItemGroup>
-        <DafnyVerifParams Include="timeLimit:100" />
+        <VerifyDafnyPassthrough Include="timeLimit:100" />
     </ItemGroup>
 </Project>

--- a/Test/TestProject/TestProject.csproj
+++ b/Test/TestProject/TestProject.csproj
@@ -21,7 +21,7 @@
     <Import Project="../../Source/dafny.msbuild/build/dafny.msbuild.props" />
     <Import Project="../../Source/dafny.msbuild/build/dafny.msbuild.targets" />
 
-    <PropertyGroup>
-        <DafnyVerificationTimeLimit>100</DafnyVerificationTimeLimit>
-    </PropertyGroup>
+    <ItemGroup>
+        <DafnyVerifParams Include="timeLimit:100" />
+    </ItemGroup>
 </Project>

--- a/Test/TestProject/testDefiniteAssignment.dfy
+++ b/Test/TestProject/testDefiniteAssignment.dfy
@@ -1,0 +1,24 @@
+include "shared.dfy"
+
+module TestDefiniteAssignment {
+  import opened Shared
+
+  datatype MyNewDataType = FirstExample | SecondExample
+
+  // DefiniteAssignmentExampleFunction represents a sample function that fails verification when the definiteAssignment
+  // parameter is passed into the VerifyDafnyPassthrough ItemGroup with a value or 2 or 3
+  method DefiniteAssignmentExampleFunction(example: MyNewDataType) returns (tmp: nat)
+  {
+    match example {
+      case FirstExample =>
+        // We are not assigning anything here, which should trigger definite-assignment rules when definiteAssignment:2
+        // or definiteAssignment:3 is used (since we will be returning tmp without defining it)
+      case SecondExample =>
+        tmp := 1;
+    }
+  }
+
+  function method {:test} PassingTest(): VoidOutcome {
+    VoidSuccess
+  }
+}

--- a/Test/TestProject/tests.dfy
+++ b/Test/TestProject/tests.dfy
@@ -1,4 +1,3 @@
-
 include "shared.dfy"
 
 module MyTests {

--- a/Test/TestProject/tests2.dfy
+++ b/Test/TestProject/tests2.dfy
@@ -1,8 +1,6 @@
-
 include "shared.dfy"
 
 module MyTests2 {
-  
   import opened Shared
   
   function method {:test} PassingTest(): VoidOutcome {

--- a/Test/TestProject/tests3.dfy
+++ b/Test/TestProject/tests3.dfy
@@ -1,8 +1,6 @@
-
 include "shared.dfy"
 
 module MyTests3 {
-
   import opened Shared
 
   function method {:test} PassingTest(): VoidOutcome {


### PR DESCRIPTION
Switched the verify task to take in a list of arguments (user defined) instead of pre-determined options. This allows the verify task to support new options like `definiteAssignment` without having to specifically add it.