### PR TITLE
feat: Optionally check Dafny CLI version before usage

### DIFF
--- a/Source/dafny.msbuild/DafnyVerifyTask.cs
+++ b/Source/dafny.msbuild/DafnyVerifyTask.cs
@@ -76,13 +76,12 @@ namespace DafnyMSBuild
             }
             args.Add(file.ItemSpec);
 
-            using var verifyProcess = Utils.RunProcess(DafnyExecutable, args);
+            using var verifyProcess = Utils.RunProcess(DafnyExecutable, args, out var stdout);
             bool success = verifyProcess.ExitCode == 0;
 
             Log.LogMessage(MessageImportance.High, "Verifying {0} {1}", file.ItemSpec, success ? "succeeded!" : "failed:");
             if (!success) {
-                string output = verifyProcess.StandardOutput.ReadToEnd();
-                Log.LogMessage(MessageImportance.High, output);
+                Log.LogMessage(MessageImportance.High, stdout);
             }
             return success;
         }

--- a/Source/dafny.msbuild/DafnyVersionCheckTask.cs
+++ b/Source/dafny.msbuild/DafnyVersionCheckTask.cs
@@ -1,0 +1,157 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Microsoft.Build.Framework;
+using Task = Microsoft.Build.Utilities.Task;
+
+namespace DafnyMSBuild
+{
+    /**
+     * A custom Task for checking that the provided Dafny CLI is of a compatible version.
+     */
+    public class DafnyVersionCheckTask : Task
+    {
+        public string DafnyBinariesDir { get; set; }
+
+        [Required]
+        public string DafnyExecutablePath { get; set; }
+
+        // Either a Dafny version number, like "2.3.0.10506", or the empty string.
+        public string DafnyVersion { get; set; }
+
+        // Either a Git commit hash, or the empty string.
+        public string DafnyVersionCommit { get; set; }
+
+        // Either a Git tag name, or the empty string.
+        public string DafnyVersionTag { get; set; }
+
+        public override bool Execute()
+        {
+            var foundDafnyVersion = GetDafnyExecutableVersion(DafnyExecutablePath);
+
+            var enforceVersion = !string.IsNullOrEmpty(DafnyVersion);
+            var enforceCommit = !string.IsNullOrEmpty(DafnyVersionCommit);
+            var enforceTag = !string.IsNullOrEmpty(DafnyVersionTag);
+            if (!(enforceVersion || enforceCommit || enforceTag)) return Success(foundDafnyVersion);
+            if (new[] {enforceVersion, enforceCommit, enforceTag}.Count(b => b) > 1) {
+                return Fail("The DafnyVersion, DafnyVersionCommit, and DafnyVersionTag properties are mutually exclusive");
+            }
+
+            if (enforceVersion) return DafnyVersion == foundDafnyVersion
+                ? Success(foundDafnyVersion)
+                : Fail($"Expected Dafny version \"{DafnyVersion}\", found \"{foundDafnyVersion}\"");
+
+            var expectedRepoHead = enforceCommit ? $"commit {DafnyVersionCommit}" : $"tag {DafnyVersionTag}";
+            if (string.IsNullOrEmpty(DafnyBinariesDir))
+            {
+                return Fail("DafnyBinariesDir must be set to a directory within a Git repo in order to check DafnyVersionCommit or DafnyVersionTag");
+            }
+            if (IsGitWorkingTreeDirty(DafnyBinariesDir))
+            {
+                return Fail($"Expected Dafny executable Git repo at {expectedRepoHead}, but working tree or index has changes");
+            }
+
+            var specifiedCommitHash = enforceCommit ? DafnyVersionCommit : GetCommitHashForGitTag(DafnyBinariesDir, DafnyVersionTag);
+            var repoHeadCommitHash = GetGitRepoHeadCommitHash(DafnyBinariesDir);
+            return repoHeadCommitHash != null && repoHeadCommitHash == specifiedCommitHash
+                ? Success(foundDafnyVersion)
+                : Fail($"Expected Dafny executable Git repo at {expectedRepoHead}, but HEAD is at {repoHeadCommitHash}");
+        }
+
+        /**
+         * Prints a success message and returns true.
+         */
+        private bool Success(string version)
+        {
+            Log.LogMessage(MessageImportance.High, "Found Dafny version {0}", version);
+            return true;
+        }
+
+        /**
+         * Prints the given failure message and returns false.
+         */
+        private bool Fail(string message)
+        {
+            Log.LogError(message);
+            return false;
+        }
+
+        /**
+         * Returns the Dafny version (as printed during execution) and full path; or null, if the process does not print its version in a parseable manner.
+         */
+        private static string GetDafnyExecutableVersion(string dafnyExecutablePath)
+        {
+            using var process = new Process
+            {
+                StartInfo = {FileName = dafnyExecutablePath, CreateNoWindow = true, UseShellExecute = false, RedirectStandardOutput = true}
+            };
+            // Dafny prints its version only if given at least one input file. With an invalid file name, it will print its version, then immediately exit.
+            process.StartInfo.ArgumentList.Add("");
+            process.Start();
+            process.WaitForExit();
+
+            var output = process.StandardOutput.ReadLine() ?? "";
+            var match = new Regex("^Dafny ([0-9.]+)$").Match(output);
+            return match.Success ? match.Groups[1].Value : null;
+        }
+
+        /**
+         * Returns the HEAD commit hash of the Git repository containing the working directory, or null if an error occurred.
+         */
+        private static string GetGitRepoHeadCommitHash(string workingDir)
+        {
+            using var process = RunGitProcess(workingDir, new[] {"show-ref", "-s", "--verify", "HEAD"});
+            return process.ExitCode == 0 ? process.StandardOutput.ReadLine() : null;
+        }
+
+        /**
+         * Returns the commit hash corresponding to the given tag name, or null if an error occurred.
+         */
+        private static string GetCommitHashForGitTag(string workingDir, string tagName)
+        {
+            using var process = RunGitProcess(workingDir, new[] {"show-ref", "-s", "--verify", $"refs/tags/{tagName}"});
+            return process.ExitCode == 0 ? process.StandardOutput.ReadLine() : null;
+        }
+
+        /**
+         * Returns true if the Git repository containing the working directory is dirty (has changes in its index or work tree).
+         */
+        private static bool IsGitWorkingTreeDirty(string workingDir)
+        {
+            using var process = RunGitProcess(workingDir, new[] {"diff-index", "--quiet", "HEAD", "--"});
+            return process.ExitCode switch
+            {
+                0 => false,
+                1 => true,
+                _ => throw new Exception("`git diff-index` failed")
+            };
+        }
+
+        /**
+         * Runs Git in the given working directory and with the given arguments, and returns the Process.
+         * This assumes that `git` is in the user's PATH variable.
+         * The caller is responsible for disposing of the returned Process.
+         */
+        private static Process RunGitProcess(string workingDir, IEnumerable<string> args)
+        {
+            var process = new Process
+            {
+                StartInfo =
+                {
+                    FileName = "git",
+                    CreateNoWindow = true,
+                    UseShellExecute = false,
+                    WorkingDirectory = workingDir,
+                    RedirectStandardOutput = true
+                }
+            };
+            foreach (var arg in args) process.StartInfo.ArgumentList.Add(arg);
+            process.Start();
+            process.WaitForExit();
+            return process;
+        }
+    }
+}

--- a/Source/dafny.msbuild/DafnyVersionCheckTask.cs
+++ b/Source/dafny.msbuild/DafnyVersionCheckTask.cs
@@ -86,8 +86,7 @@ namespace DafnyMSBuild
          */
         private static string GetDafnyExecutableVersion(string dafnyExecutablePath)
         {
-            using var process = Utils.RunProcess(dafnyExecutablePath, new[] { "/version" });
-            var output = process.StandardOutput.ReadLine() ?? "";
+            using var process = Utils.RunProcess(dafnyExecutablePath, new[] { "/version" }, out var output);
             var match = new Regex("^Dafny ([0-9.]+)$").Match(output);
             return match.Success ? match.Groups[1].Value : null;
         }
@@ -97,8 +96,8 @@ namespace DafnyMSBuild
          */
         private static string GetGitRepoHeadCommitHash(string workingDir)
         {
-            using var process = Utils.RunProcess("git", new[] {"show-ref", "-s", "--verify", "HEAD"}, workingDir);
-            return process.ExitCode == 0 ? process.StandardOutput.ReadLine() : null;
+            using var process = Utils.RunProcess("git", new[] {"show-ref", "-s", "--verify", "HEAD"}, out var stdout, workingDir);
+            return process.ExitCode == 0 ? stdout.Trim() : null;
         }
 
         /**
@@ -106,8 +105,8 @@ namespace DafnyMSBuild
          */
         private static string GetCommitHashForGitTag(string workingDir, string tagName)
         {
-            using var process = Utils.RunProcess("git", new[] {"show-ref", "-s", "--verify", $"refs/tags/{tagName}"}, workingDir);
-            return process.ExitCode == 0 ? process.StandardOutput.ReadLine() : null;
+            using var process = Utils.RunProcess("git", new[] {"show-ref", "-s", "--verify", $"refs/tags/{tagName}"}, out var stdout, workingDir);
+            return process.ExitCode == 0 ? stdout.Trim() : null;
         }
 
         /**
@@ -115,7 +114,7 @@ namespace DafnyMSBuild
          */
         private static bool IsGitWorkingTreeDirty(string workingDir)
         {
-            using var process = Utils.RunProcess("git", new[] {"diff-index", "--quiet", "HEAD", "--"}, workingDir);
+            using var process = Utils.RunProcess("git", new[] {"diff-index", "--quiet", "HEAD", "--"}, out _, workingDir);
             return process.ExitCode switch
             {
                 0 => false,

--- a/Source/dafny.msbuild/DafnyVersionCheckTask.cs
+++ b/Source/dafny.msbuild/DafnyVersionCheckTask.cs
@@ -41,7 +41,7 @@ namespace DafnyMSBuild
             {
                 return foundDafnyVersion == DafnyVersion
                     ? Success(foundDafnyVersion)
-                    : Fail($"Expected Dafny version \"{DafnyVersion}\", found \"{foundDafnyVersion}\"");
+                    : Fail($"Expected Dafny version {DafnyVersion}, found {foundDafnyVersion}");
             }
 
             var expectedRepoHead = enforceCommit ? $"commit {DafnyVersionCommit}" : $"tag {DafnyVersionTag}";
@@ -59,7 +59,7 @@ namespace DafnyMSBuild
                 ? DafnyVersionCommit
                 : GetCommitHashForGitTag(DafnyBinariesDir, DafnyVersionTag);
             return repoHeadCommitHash == expectedCommitHash
-                ? Success($"${DafnyVersion} in Git repository at ${expectedRepoHead}")
+                ? Success($"{DafnyVersion} in Git repository at {expectedRepoHead}")
                 : Fail($"Expected Dafny Git repository at {expectedRepoHead}, but HEAD is at commit {repoHeadCommitHash}");
         }
 

--- a/Source/dafny.msbuild/Utils.cs
+++ b/Source/dafny.msbuild/Utils.cs
@@ -32,7 +32,7 @@ namespace DafnyMSBuild
                     RedirectStandardOutput = true
                 }
             };
-            foreach (var arg in args) process.StartInfo.ArgumentList.Add(arg);
+            args.ForEach(process.StartInfo.ArgumentList.Add);
             process.Start();
 
             // We must read before waiting, or else deadlock is possible.

--- a/Source/dafny.msbuild/Utils.cs
+++ b/Source/dafny.msbuild/Utils.cs
@@ -32,7 +32,7 @@ namespace DafnyMSBuild
                     RedirectStandardOutput = true
                 }
             };
-            args.ForEach(process.StartInfo.ArgumentList.Add);
+            foreach (var arg in args) process.StartInfo.ArgumentList.Add(arg);
             process.Start();
 
             // We must read before waiting, or else deadlock is possible.

--- a/Source/dafny.msbuild/Utils.cs
+++ b/Source/dafny.msbuild/Utils.cs
@@ -6,16 +6,20 @@ namespace DafnyMSBuild
     internal static class Utils
     {
         /**
-         * Runs the executable with arguments in the given working directory, and returns the Process.
+         * <summary>
+         * Runs the executable with arguments in the given working directory, waits for the process to exit,
+         * and returns the Process.
+         * The <paramref name="stdout"/> out-parameter is set to the full standard output.
          * The caller is responsible for disposing of the returned Process.
+         * </summary>
          * <example>
          * <code>
-         * using var process = RunProcess("git", new[] { "rev-parse", "HEAD" }, ".");
-         * var headHash = process.ExitCode == 0 ? process.StandardOutput.ReadLine() : null;
+         * using var process = RunProcess("git", new[] { "rev-parse", "HEAD" }, out var stdout, ".");
+         * var headHash = process.ExitCode == 0 ? stdout : null;
          * </code>
          * </example>
          */
-        public static Process RunProcess(string executable, IEnumerable<string> args, string workingDir = "")
+        public static Process RunProcess(string executable, IEnumerable<string> args, out string stdout, string workingDir = "")
         {
             var process = new Process
             {
@@ -30,7 +34,12 @@ namespace DafnyMSBuild
             };
             foreach (var arg in args) process.StartInfo.ArgumentList.Add(arg);
             process.Start();
+
+            // We must read before waiting, or else deadlock is possible.
+            // See <https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.process.standardoutput>.
+            stdout = process.StandardOutput.ReadToEnd();
             process.WaitForExit();
+
             return process;
         }
     }

--- a/Source/dafny.msbuild/Utils.cs
+++ b/Source/dafny.msbuild/Utils.cs
@@ -32,7 +32,10 @@ namespace DafnyMSBuild
                     RedirectStandardOutput = true
                 }
             };
-            foreach (var arg in args) process.StartInfo.ArgumentList.Add(arg);
+            foreach (var arg in args)
+            {
+                process.StartInfo.ArgumentList.Add(arg);
+            }
             process.Start();
 
             // We must read before waiting, or else deadlock is possible.

--- a/Source/dafny.msbuild/Utils.cs
+++ b/Source/dafny.msbuild/Utils.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 
 namespace DafnyMSBuild
 {

--- a/Source/dafny.msbuild/Utils.cs
+++ b/Source/dafny.msbuild/Utils.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 
 namespace DafnyMSBuild
 {

--- a/Source/dafny.msbuild/Utils.cs
+++ b/Source/dafny.msbuild/Utils.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace DafnyMSBuild
+{
+    internal static class Utils
+    {
+        /**
+         * Runs the executable with arguments in the given working directory, and returns the Process.
+         * The caller is responsible for disposing of the returned Process.
+         * <example>
+         * <code>
+         * using var process = RunProcess("git", new[] { "rev-parse", "HEAD" }, ".");
+         * var headHash = process.ExitCode == 0 ? process.StandardOutput.ReadLine() : null;
+         * </code>
+         * </example>
+         */
+        public static Process RunProcess(string executable, IEnumerable<string> args, string workingDir = "")
+        {
+            var process = new Process
+            {
+                StartInfo =
+                {
+                    FileName = executable,
+                    CreateNoWindow = true,
+                    UseShellExecute = false,
+                    WorkingDirectory = workingDir,
+                    RedirectStandardOutput = true
+                }
+            };
+            foreach (var arg in args) process.StartInfo.ArgumentList.Add(arg);
+            process.Start();
+            process.WaitForExit();
+            return process;
+        }
+    }
+}

--- a/Source/dafny.msbuild/build/dafny.msbuild.props
+++ b/Source/dafny.msbuild/build/dafny.msbuild.props
@@ -7,7 +7,7 @@
         <Dafny Condition="'$(OS)' == 'Windows_NT'">Dafny.exe</Dafny>
         <Dafny Condition="'$(OS)' != 'Windows_NT'">dafny</Dafny>
 
-        <!-- 
+        <!--
         TODO: This is to avoid lots of warnings from the Dafny-generated code
         for things like unused variables and unreachable code. It's unfortunate
         that we then won't get these warnings for hand-written C# code either, though.
@@ -16,11 +16,19 @@
          -->
         <NoWarn>0164;0219;1717;0162;0168</NoWarn>
 
-        <!-- 
+        <!--
         Defaulting to an empty string means we assume that the Dafny
         Binaries directory is already on your $PATH
         -->
         <DafnyBinariesDir></DafnyBinariesDir>
+
+        <!-- Optional, mutually-exclusive properties for Dafny-lang CLI version checking. -->
+        <!--suppress CheckTagEmptyBody -->
+        <DafnyVersion></DafnyVersion>
+        <!--suppress CheckTagEmptyBody -->
+        <DafnyVersionTag></DafnyVersionTag>
+        <!--suppress CheckTagEmptyBody -->
+        <DafnyVersionCommit></DafnyVersionCommit>
     </PropertyGroup>
 
     <ItemGroup>
@@ -33,4 +41,5 @@
     </ItemGroup>
 
     <UsingTask TaskName="DafnyMSBuild.DafnyVerifyTask" AssemblyFile="$(TaskAssembly)"/>
+    <UsingTask TaskName="DafnyMSBuild.DafnyVersionCheckTask" AssemblyFile="$(TaskAssembly)"/>
 </Project>

--- a/Source/dafny.msbuild/build/dafny.msbuild.props
+++ b/Source/dafny.msbuild/build/dafny.msbuild.props
@@ -20,6 +20,7 @@
         Defaulting to an empty string means we assume that the Dafny
         Binaries directory is already on your $PATH
         -->
+        <!--suppress CheckTagEmptyBody -->
         <DafnyBinariesDir></DafnyBinariesDir>
 
         <!-- Optional, mutually-exclusive properties for Dafny-lang CLI version checking. -->

--- a/Source/dafny.msbuild/build/dafny.msbuild.targets
+++ b/Source/dafny.msbuild/build/dafny.msbuild.targets
@@ -1,17 +1,27 @@
 <Project>
     <!-- TODO: hook this up as a CodeAnalysis plugin instead? -->
     <Target Name="VerifyDafny">
-        <DafnyVerifyTask DafnySourceFiles="@(DafnySource)" 
+        <DafnyVersionCheckTask DafnyBinariesDir="$(DafnyBinariesDir)"
+                               DafnyExecutablePath="$(DafnyBinariesDir)$(Dafny)"
+                               DafnyVersion="$(DafnyVersion)"
+                               DafnyVersionCommit="$(DafnyVersionCommit)"
+                               DafnyVersionTag="$(DafnyVersionTag)" />
+        <DafnyVerifyTask DafnySourceFiles="@(DafnySource)"
                          DafnyExecutable="$(DafnyBinariesDir)$(Dafny)"
                          Jobs="$(VerifyDafnyJobs)"
                          DafnyVerificationParams="@(VerifyDafnyPassthrough)" />
     </Target>
-    
+
     <Target Name="CompileDafny"
             AfterTargets="ResolveReferences"
             BeforeTargets="CoreCompile"
             Inputs="$(MSBuildProjectFile);@(DafnySource)"
             Outputs="$(IntermediateOutputPath)GeneratedFromDafny.cs">
+        <DafnyVersionCheckTask DafnyBinariesDir="$(DafnyBinariesDir)"
+                               DafnyExecutablePath="$(DafnyBinariesDir)$(Dafny)"
+                               DafnyVersion="$(DafnyVersion)"
+                               DafnyVersionCommit="$(DafnyVersionCommit)"
+                               DafnyVersionTag="$(DafnyVersionTag)" />
         <PropertyGroup>
             <DafnyOutputFile>$(IntermediateOutputPath)GeneratedFromDafny.cs</DafnyOutputFile>
         </PropertyGroup>
@@ -26,6 +36,11 @@
 
     <!-- TODO: Define Inputs and Outputs for this -->
     <Target Name="CompileDafnyToJS">
+        <DafnyVersionCheckTask DafnyBinariesDir="$(DafnyBinariesDir)"
+                               DafnyExecutablePath="$(DafnyBinariesDir)$(Dafny)"
+                               DafnyVersion="$(DafnyVersion)"
+                               DafnyVersionCommit="$(DafnyVersionCommit)"
+                               DafnyVersionTag="$(DafnyVersionTag)" />
         <Exec Command="$(Dafny) /out:build/Main @(DafnySource, ' ') /compile:2 /noVerify /noIncludes /compileTarget:js /spillTargetCode:1" />
     </Target>
 </Project>

--- a/Test/TestProject/TestProject.csproj
+++ b/Test/TestProject/TestProject.csproj
@@ -22,7 +22,7 @@
     <Import Project="../../Source/dafny.msbuild/build/dafny.msbuild.targets" />
 
     <PropertyGroup>
-        <DafnyVersion>2.3.0.10506</DafnyVersion>
+        <DafnyVersionTag>v3.5.0</DafnyVersionTag>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Test/TestProject/TestProject.csproj
+++ b/Test/TestProject/TestProject.csproj
@@ -22,7 +22,8 @@
     <Import Project="../../Source/dafny.msbuild/build/dafny.msbuild.targets" />
 
     <PropertyGroup>
-        <DafnyVersionTag>v3.5.0</DafnyVersionTag>
+        <!-- Corresponds to tag v3.5.0, which we can't check directly since we no longer install Dafny from source -->
+        <DafnyVersion>3.5.0.40314</DafnyVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Test/TestProject/TestProject.csproj
+++ b/Test/TestProject/TestProject.csproj
@@ -11,15 +11,19 @@
 
     <!--
         Normally a project just has to reference this package like this:
-        
+
         <PackageReference Include="dafny.msbuild" Version="*.*.*" />
-        
+
         But to test the functionality without packaging up the nupkg itself,
         we import the properties and target directly in the same way nuget
         will automatically instead.
     -->
     <Import Project="../../Source/dafny.msbuild/build/dafny.msbuild.props" />
     <Import Project="../../Source/dafny.msbuild/build/dafny.msbuild.targets" />
+
+    <PropertyGroup>
+        <DafnyVersion>2.3.0.10506</DafnyVersion>
+    </PropertyGroup>
 
     <ItemGroup>
         <VerifyDafnyPassthrough Include="timeLimit:100" />


### PR DESCRIPTION
This PR allows consumers of dafny.msbuild to optionally constrain the version of the Dafny CLI used for verification and compilation, using a version string (`DafnyVersion`), a Git commit hash (`DafnyVersionCommit`), or a Git tag name (`DafnyVersionTag`). If one is specified, then dafny.msbuild Tasks will check that the provided Dafny CLI matches the specified version. Using either a Git commit hash or tag name, requires that the `DafnyBinariesDir` property is set to a directory within a local dafny-lang Git repository.

Resolves #16.